### PR TITLE
chore: migrate dependency resolution to Policyfile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ name: ci
 
 jobs:
   lint-unit:
-    uses: sous-chefs/.github/.github/workflows/lint-unit.yml@8.0.2
+    uses: sous-chefs/.github/.github/workflows/lint-unit.yml@8.0.4
     permissions:
       actions: write
       checks: write
@@ -34,7 +34,7 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v7
       - name: Install Chef
-        uses: sous-chefs/.github/.github/actions/install-workstation@8.0.2
+        uses: sous-chefs/.github/.github/actions/install-workstation@8.0.4
       - name: Dokken
         uses: actionshub/test-kitchen@main
         env:

--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -7,7 +7,7 @@ name: 'Validate PR'
 
 jobs:
   conventional-commits:
-    uses: sous-chefs/.github/.github/workflows/conventional-commits.yml@8.0.2
+    uses: sous-chefs/.github/.github/workflows/conventional-commits.yml@8.0.4
     permissions:
       pull-requests: read
     secrets: inherit

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -19,6 +19,6 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v7
       - name: Install Chef
-        uses: actionshub/chef-install@main
+        uses: sous-chefs/.github/.github/actions/install-workstation@8.0.4
       - name: Install cookbooks
-        run: berks install
+        run: chef install Policyfile.rb

--- a/.github/workflows/prevent-file-change.yml
+++ b/.github/workflows/prevent-file-change.yml
@@ -7,7 +7,7 @@ name: 'Prevent file change'
 
 jobs:
   prevent-file-change:
-    uses: sous-chefs/.github/.github/workflows/prevent-file-change.yml@8.0.2
+    uses: sous-chefs/.github/.github/workflows/prevent-file-change.yml@8.0.4
     permissions:
       pull-requests: write
     secrets:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ permissions:
 
 jobs:
   release:
-    uses: sous-chefs/.github/.github/workflows/release-cookbook.yml@8.0.2
+    uses: sous-chefs/.github/.github/workflows/release-cookbook.yml@8.0.4
     secrets:
       token: ${{ secrets.PORTER_GITHUB_TOKEN }}
       supermarket_user: ${{ secrets.CHEF_SUPERMARKET_USER }}

--- a/.gitignore
+++ b/.gitignore
@@ -36,7 +36,6 @@ doc/
 rdoc
 
 # chef infra stuff
-Berksfile.lock
 .kitchen
 kitchen.local.yml
 vendor/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,30 +19,30 @@ already-present certificate store.
 
 ### Chef Infra Client
 
-- Red Hat Enterprise Linux: `8.x`, `9.x`, `10.x` on `x86_64`; `8.x` and `9.x` also support `aarch64`
-- Ubuntu LTS: `20.04`, `22.04`, `24.04` on `x86_64`; `20.04+` also supports `aarch64`
-- macOS: `13.x`, `14.x` on `aarch64`
-- Windows: `2016`, `2019`, `2022`, `2025`, `10`, and `11` on `x86_64`
+* Red Hat Enterprise Linux: `8.x`, `9.x`, `10.x` on `x86_64`; `8.x` and `9.x` also support `aarch64`
+* Ubuntu LTS: `20.04`, `22.04`, `24.04` on `x86_64`; `20.04+` also supports `aarch64`
+* macOS: `13.x`, `14.x` on `aarch64`
+* Windows: `2016`, `2019`, `2022`, `2025`, `10`, and `11` on `x86_64`
 
 ### Chef Workstation / Legacy ChefDK
 
-- Chef Workstation omnibus packages support Red Hat Enterprise Linux / CentOS `7.x`, `8.x`, `9.x` on `x86_64`
-- Chef Workstation omnibus packages support Ubuntu `18.04`, `20.04`, `22.04` on `x86_64`
-- Chef Workstation omnibus packages support macOS `13.x`, `14.x` on `aarch64`
-- Chef Workstation omnibus packages support Windows `10`, `11`, `Server 2016`, `Server 2019`, and `Server 2022` on `x64`
-- Legacy `chefdk` installs used `/opt/chefdk` on Unix-like systems and `C:/opscode/chefdk` on Windows
+* Chef Workstation omnibus packages support Red Hat Enterprise Linux / CentOS `7.x`, `8.x`, `9.x` on `x86_64`
+* Chef Workstation omnibus packages support Ubuntu `18.04`, `20.04`, `22.04` on `x86_64`
+* Chef Workstation omnibus packages support macOS `13.x`, `14.x` on `aarch64`
+* Chef Workstation omnibus packages support Windows `10`, `11`, `Server 2016`, `Server 2019`, and `Server 2022` on `x64`
+* Legacy `chefdk` installs used `/opt/chefdk` on Unix-like systems and `C:/opscode/chefdk` on Windows
 
 ## Architecture Limitations
 
-- Chef Infra Client has broader architecture coverage than Chef Workstation; this cookbook only exposes file-path targeting and doesn't validate package availability itself
-- Chef Workstation omnibus support is narrower than Chef Infra Client support and is primarily `x86_64` on Linux
+* Chef Infra Client has broader architecture coverage than Chef Workstation; this cookbook only exposes file-path targeting and doesn't validate package availability itself
+* Chef Workstation omnibus support is narrower than Chef Infra Client support and is primarily `x86_64` on Linux
 
 ## Source / Compiled Installation
 
-- No source build flow applies here
-- The cookbook assumes Chef Infra Client, Chef Workstation, or legacy ChefDK is already installed and that the target `cacert.pem` path exists or is intentionally overridden with `cacert_path`
+* No source build flow applies here
+* The cookbook assumes Chef Infra Client, Chef Workstation, or legacy ChefDK is already installed and that the target `cacert.pem` path exists or is intentionally overridden with `cacert_path`
 
 ## Known Issues
 
-- Chef Workstation 26 moved to Habitat-based packaging and no longer ships the historical omnibus layout under `/opt/chef-workstation/embedded/...`; this cookbook targets the omnibus-style certificate path and keeps `:chefdk` support only for legacy installs
-- This cookbook doesn't manage repository setup, package installation, or directory creation for missing Chef product paths
+* Chef Workstation 26 moved to Habitat-based packaging and no longer ships the historical omnibus layout under `/opt/chef-workstation/embedded/...`; this cookbook targets the omnibus-style certificate path and keeps `:chefdk` support only for legacy installs
+* This cookbook doesn't manage repository setup, package installation, or directory creation for missing Chef product paths

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,15 @@
-# Limitations
+# AGENTS.md
+
+## Cookbook Purpose
+
+Adds a certificate bundle to the Chef Infra Client or Workstation cacert file
+
+## Agent Findings
+
+* This cookbook is in an incremental modernization pass. Preserve existing public recipes and attributes unless a later full migration is explicitly selected.
+* Dependency management should use `Policyfile.rb`; do not reintroduce Berkshelf.
+
+## Known Limitations
 
 As of April 21, 2026, this cookbook manages the `cacert.pem` trust bundle used by existing
 Chef omnibus installs. It doesn't install Chef products; it only appends a CA bundle to an

--- a/Berksfile
+++ b/Berksfile
@@ -1,6 +1,0 @@
-# frozen_string_literal: true
-
-source 'https://supermarket.chef.io'
-cookbook 'test', path: './test/cookbooks/test'
-
-metadata

--- a/Policyfile.rb
+++ b/Policyfile.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+name 'chef_ca'
+
+run_list 'test::default'
+
+cookbook 'chef_ca', path: '.'
+cookbook 'test', path: './test/cookbooks/test'
+
+Dir.children('./test/cookbooks/test/recipes').grep(/\.rb\z/).sort.each do |recipe|
+  recipe_name = File.basename(recipe, '.rb')
+
+  named_run_list recipe_name.to_sym, 'test::' + recipe_name
+end

--- a/chefignore
+++ b/chefignore
@@ -85,8 +85,6 @@ test/*
 
 # Berkshelf #
 #############
-Berksfile
-Berksfile.lock
 cookbooks/*
 tmp
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require 'chefspec'
-require 'chefspec/berkshelf'
+require 'chefspec/policyfile'
 
 require_relative '../libraries/chef_ca'
 


### PR DESCRIPTION
## Summary
- migrate dependency resolution from Berksfile to Policyfile
- update ChefSpec setup to use Policyfile resolution
- update CI/Copilot workflow references to current sous-chefs workflow/action versions
- move cookbook limitations into AGENTS.md where present

## Verification
- chef install Policyfile.rb
- cookstyle
- /opt/chef-workstation/embedded/bin/rspec --format progress
- kitchen list